### PR TITLE
Turret align2goal

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
@@ -95,7 +95,8 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
 
     public final int APRILTAG_ID_GOAL_BLUE = 20;
     public final int APRILTAG_ID_GOAL_RED = 24;
-
+    public static double TURRET_OFFSET_RED = 0.005;
+    public static double TURRET_OFFSET_BLUE = 0.01;
 
     // DYNAMIC VARIABLES
     public double currentTrayPosition;


### PR DESCRIPTION
This pull request introduces improvements to the turret alignment logic in teleoperated mode, allowing the robot to align its turret to either the red or blue goal AprilTag with appropriate offsets. The changes make the code more flexible and precise by supporting both goals and applying goal-specific turret offsets.

Key changes include:

**Turret Alignment Enhancements:**

* Added `TURRET_OFFSET_RED` and `TURRET_OFFSET_BLUE` constants in `DarienOpModeFSM` to allow for goal-specific turret position adjustments.
* Updated the turret alignment controls in `TeleOpFSM` so that pressing `gamepad2.b` aligns to the red goal and `gamepad2.x` aligns to the blue goal, each with their respective tag IDs and offsets.
* Added logic to filter AprilTag detections based on the selected target goal, ensuring only relevant tags are considered for alignment.
* Modified the turret position calculation to use the new center position and goal-specific offset, improving alignment accuracy.

**Code Cleanup:**

* Commented out the unused `cameraOffsetX` variable in `TeleOpFSM`, reducing confusion.